### PR TITLE
fix: implement session persistence to prevent logout on page reload

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -62,9 +62,9 @@ const updateActivity = () => {
 }
 
 // Check auto-lock periodically
-const checkAutoLock = () => {
+const checkAutoLock = async () => {
   if (authStore.isAuthenticated && settingsStore.autoLockMinutes > 0) {
-    authStore.checkAutoLock(settingsStore.autoLockMinutes)
+    await authStore.checkAutoLock(settingsStore.autoLockMinutes)
     if (!authStore.isAuthenticated) {
       router.push('/auth')
     }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -66,6 +66,23 @@ router.beforeEach(async (to, _from, next) => {
     return
   }
 
+  // Try to restore session if not authenticated but session exists
+  if (!authStore.isAuthenticated) {
+    try {
+      const sessionPassword = sessionStorage.getItem('app_session_pw')
+      if (sessionPassword) {
+        const restored = await authStore.restoreSession(sessionPassword)
+        if (!restored) {
+          // Session restoration failed, clear invalid session data
+          sessionStorage.removeItem('app_session_pw')
+        }
+      }
+    } catch (error) {
+      console.error('Session restore error:', error)
+      sessionStorage.removeItem('app_session_pw')
+    }
+  }
+
   // Check authentication
   if (to.meta.requiresAuth && !authStore.isAuthenticated) {
     next({ name: 'auth' })

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -21,3 +21,11 @@ export interface SetupData {
   password: string
   githubToken: string
 }
+
+export interface AuthSession {
+  id: string
+  userName: string
+  sessionToken: string
+  lastActivity: number
+  createdAt: Date
+}


### PR DESCRIPTION
Das Problem war, dass der Auth-State nur im RAM (Pinia Store) gespeichert wurde. Bei Page Reloads (z.B. durch Vite HMR bei Component-Optimierung) wurde der State zurückgesetzt und der Benutzer zum Login umgeleitet.

Änderungen:
- AuthSession Interface in types/auth.ts hinzugefügt
- authSessions Table in Dexie (IndexedDB) für Session-Persistierung
- saveSession() und restoreSession() Methoden im Auth Store
- Passwort temporär im sessionStorage (nur für Browser-Session)
- Router Guard prüft und stellt Session bei Page Reload wieder her
- logout() und checkAutoLock() löschen Session und sessionStorage

Sicherheit:
- sessionStorage wird beim Schließen des Browsers/Tabs gelöscht
- Passwort-Verschlüsselung bleibt erhalten (PBKDF2 + AES-256)
- Session-Daten in IndexedDB für Persistierung